### PR TITLE
add support for dynamic app shortcuts

### DIFF
--- a/sample/src/main/java/com/example/shortbread/SampleApplication.java
+++ b/sample/src/main/java/com/example/shortbread/SampleApplication.java
@@ -10,6 +10,17 @@ public class SampleApplication extends Application {
     public void onCreate() {
         super.onCreate();
 
-        Shortbread.create(this);
+        // white listed
+        Shortbread.generate(this)
+                .disableAll()
+                .setEnabled(R.id.books, true)
+                .setEnabled(R.id.favorite_books, true)
+                .build();
+
+        // black listed
+//        Shortbread.generate(this)
+//                .setEnabled(R.id.books, false)
+//                .setEnabled(R.id.favorite_books, false)
+//                .build();
     }
 }

--- a/sample/src/main/java/com/example/shortbread/SampleApplication.java
+++ b/sample/src/main/java/com/example/shortbread/SampleApplication.java
@@ -22,5 +22,6 @@ public class SampleApplication extends Application {
 //                .setEnabled(R.id.books, false)
 //                .setEnabled(R.id.favorite_books, false)
 //                .build();
+
     }
 }

--- a/sample/src/main/java/com/example/shortbread/books/BooksActivity.java
+++ b/sample/src/main/java/com/example/shortbread/books/BooksActivity.java
@@ -8,7 +8,7 @@ import com.example.shortbread.R;
 
 import shortbread.Shortcut;
 
-@Shortcut(id = "books", icon = R.drawable.ic_shortcut_books, shortLabelRes = R.string.label_books, rank = 1)
+@Shortcut(id = R.id.books, icon = R.drawable.ic_shortcut_books, shortLabelRes = R.string.label_books, rank = 1)
 public class BooksActivity extends Activity {
 
     @Override
@@ -17,7 +17,7 @@ public class BooksActivity extends Activity {
         setContentView(R.layout.activity_books);
     }
 
-    @Shortcut(id = "favorite_books", icon = R.drawable.ic_shortcut_favorite, shortLabel = "Favorite books", rank = 2,
+    @Shortcut(id = R.id.favorite_books, icon = R.drawable.ic_shortcut_favorite, shortLabel = "Favorite books", rank = 2,
             disabledMessage = "You have no favorite books")
     public void showFavoriteBooks() {
         Toast.makeText(this, "Favorite books", Toast.LENGTH_SHORT).show();

--- a/sample/src/main/java/com/example/shortbread/movies/MoviesActivity.java
+++ b/sample/src/main/java/com/example/shortbread/movies/MoviesActivity.java
@@ -10,7 +10,7 @@ import com.example.shortbread.books.BooksActivity;
 
 import shortbread.Shortcut;
 
-@Shortcut(id = "movies", action = "movie_shortcut", icon = R.drawable.ic_shortcut_movies, rank = 3,
+@Shortcut(id = R.id.movies, action = "movie_shortcut", icon = R.drawable.ic_shortcut_movies, rank = 3,
         backStack = {MainActivity.class, BooksActivity.class})
 public class MoviesActivity extends Activity {
 
@@ -20,7 +20,7 @@ public class MoviesActivity extends Activity {
         setContentView(R.layout.activity_movies);
     }
 
-    @Shortcut(id = "add_movie", icon = R.drawable.ic_shortcut_add, shortLabel = "Add movie", rank = 4, disabledMessageRes = R.string.label_books)
+    @Shortcut(id = R.id.add_movies, icon = R.drawable.ic_shortcut_add, shortLabel = "Add movie", rank = 4, disabledMessageRes = R.string.label_books)
     public void addMovie() {
         Toast.makeText(this, "Add movie", Toast.LENGTH_SHORT).show();
     }

--- a/sample/src/main/res/values/ids.xml
+++ b/sample/src/main/res/values/ids.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="movies" type="id" />
+    <item name="add_movies" type="id" />
+    <item name="books" type="id" />
+    <item name="favorite_books" type="id" />
+</resources>

--- a/shortbread-annotations/src/main/java/shortbread/Shortcut.java
+++ b/shortbread-annotations/src/main/java/shortbread/Shortcut.java
@@ -1,6 +1,7 @@
 package shortbread;
 
 import android.support.annotation.DrawableRes;
+import android.support.annotation.IdRes;
 import android.support.annotation.IntRange;
 import android.support.annotation.StringRes;
 
@@ -10,7 +11,8 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.METHOD})
 public @interface Shortcut {
 
-    String id();
+    @IdRes
+    int id();
 
     String shortLabel() default "";
 

--- a/shortbread-compiler/src/main/java/shortbread/CodeGenerator.java
+++ b/shortbread-compiler/src/main/java/shortbread/CodeGenerator.java
@@ -11,7 +11,6 @@ import com.squareup.javapoet.TypeSpec;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +37,6 @@ class CodeGenerator {
     private final ClassName componentName = ClassName.get("android.content", "ComponentName");
     private final ClassName list = ClassName.get("java.util", "List");
     private final TypeName listOfShortcutInfo = ParameterizedTypeName.get(list, shortcutInfo);
-    private final TypeName listOfListOfShortcutInfo = ParameterizedTypeName.get(list, listOfShortcutInfo);
     private final ClassName taskStackBuilder = ClassName.get("android.app", "TaskStackBuilder");
     private final ClassName shortcutUtils = ClassName.get("shortbread", "ShortcutUtils");
 
@@ -75,10 +73,9 @@ class CodeGenerator {
     private MethodSpec createShortcuts() {
         final MethodSpec.Builder methodBuilder = MethodSpec.methodBuilder("createShortcuts")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .returns(listOfListOfShortcutInfo)
+                .returns(listOfShortcutInfo)
                 .addParameter(context, "context")
-                .addStatement("$T<$T> enabledShortcuts = new $T<>()", List.class, shortcutInfo, ArrayList.class)
-                .addStatement("$T<$T> disabledShortcuts = new $T<>()", List.class, shortcutInfo, ArrayList.class);
+                .addStatement("$T<$T> enabledShortcuts = new $T<>()", List.class, shortcutInfo, ArrayList.class);
 
         for (final ShortcutAnnotatedElement annotatedElement : annotatedElements) {
             Shortcut shortcut = annotatedElement.getShortcut();
@@ -88,7 +85,7 @@ class CodeGenerator {
         }
 
         return methodBuilder
-                .addStatement("return $T.asList(enabledShortcuts, disabledShortcuts)", Arrays.class)
+                .addStatement("return enabledShortcuts")
                 .build();
     }
 

--- a/shortbread/src/main/java/shortbread/Creator.java
+++ b/shortbread/src/main/java/shortbread/Creator.java
@@ -1,0 +1,89 @@
+package shortbread;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.app.Application;
+import android.content.Context;
+import android.content.pm.ShortcutInfo;
+import android.content.pm.ShortcutManager;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.annotation.RequiresApi;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+class Creator {
+
+    private static boolean activityLifecycleCallbacksSet;
+    private static boolean shortcutsSet;
+
+
+    @TargetApi(25)
+    static void create(Context context, List<ShortcutInfo> allShortcuts, boolean[] shortCutStatus) {
+        if (Build.VERSION.SDK_INT < 25) {
+            return;
+        }
+
+        Context applicationContext = context.getApplicationContext();
+
+        if (!shortcutsSet) {
+            setShortcuts(applicationContext, allShortcuts, shortCutStatus);
+        }
+
+        if (!activityLifecycleCallbacksSet) {
+            setActivityLifecycleCallbacks(applicationContext);
+        }
+
+        if (context instanceof Activity) {
+            callMethodShortcut((Activity) context);
+        }
+    }
+
+    @RequiresApi(14)
+    private static void setActivityLifecycleCallbacks(Context applicationContext) {
+        ((Application) applicationContext).registerActivityLifecycleCallbacks(new SimpleActivityLifecycleCallbacks() {
+
+            @Override
+            public void onActivityCreated(final Activity activity, final Bundle savedInstanceState) {
+                callMethodShortcut(activity);
+            }
+        });
+
+        activityLifecycleCallbacksSet = true;
+    }
+
+    @RequiresApi(25)
+    private static void setShortcuts(Context context, List<ShortcutInfo> allShortcuts, boolean[] shortcutStates) {
+        ShortcutManager shortcutManager = context.getSystemService(ShortcutManager.class);
+
+        //noinspection TryWithIdenticalCatches
+        shortcutManager.removeAllDynamicShortcuts();
+        shortcutManager.setDynamicShortcuts(allShortcuts);
+        List<String> disabledShortcuts = new ArrayList<>();
+        for (int i = 0; i < shortcutStates.length; i++) {
+            if (!shortcutStates[i]) {
+                disabledShortcuts.add(allShortcuts.get(i).getId());
+            }
+        }
+        shortcutManager.disableShortcuts(disabledShortcuts);
+        shortcutsSet = true;
+    }
+
+    private static void callMethodShortcut(Activity activity) {
+        //noinspection TryWithIdenticalCatches
+        try {
+            Method callMethodShortcut = Shortbread.generated.getMethod("callMethodShortcut", Activity.class);
+
+            callMethodShortcut.invoke(Shortbread.generated, activity);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (InvocationTargetException e) {
+            e.printStackTrace();
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/shortbread/src/main/java/shortbread/Shortbread.java
+++ b/shortbread/src/main/java/shortbread/Shortbread.java
@@ -1,110 +1,33 @@
 package shortbread;
 
 import android.annotation.TargetApi;
-import android.app.Activity;
-import android.app.Application;
 import android.content.Context;
 import android.content.pm.ShortcutInfo;
-import android.content.pm.ShortcutManager;
-import android.os.Build;
-import android.os.Bundle;
-import android.support.annotation.RequiresApi;
+import android.support.annotation.NonNull;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.List;
 
 public final class Shortbread {
 
-    private static Class<?> generated;
-    private static Method createShortcuts;
-    private static Method callMethodShortcut;
-    private static boolean shortcutsSet;
-    private static boolean activityLifecycleCallbacksSet;
+    static Class<?> generated;
 
     @TargetApi(25)
-    public static void create(Context context) {
-        if (Build.VERSION.SDK_INT < 25) {
-            return;
-        }
+    @NonNull
+    public static ShortbreadBuilder generate(Context context) {
+        final Object returnValue;
 
-        Context applicationContext = context.getApplicationContext();
-
-        if (generated == null) {
-            //noinspection TryWithIdenticalCatches
-            try {
-                generated = Class.forName("shortbread.ShortbreadGenerated");
-                createShortcuts = generated.getMethod("createShortcuts", Context.class);
-                callMethodShortcut = generated.getMethod("callMethodShortcut", Activity.class);
-            } catch (ClassNotFoundException e) {
-                e.printStackTrace();
-            } catch (NoSuchMethodException e) {
-                e.printStackTrace();
-            }
-        }
-
-        if (!shortcutsSet) {
-            setShortcuts(applicationContext);
-        }
-
-        if (!activityLifecycleCallbacksSet) {
-            setActivityLifecycleCallbacks(applicationContext);
-        }
-
-        if (context instanceof Activity) {
-            callMethodShortcut((Activity) context);
-        }
-    }
-
-    @RequiresApi(25)
-    private static void setShortcuts(Context context) {
-        ShortcutManager shortcutManager = context.getSystemService(ShortcutManager.class);
-
-        //noinspection TryWithIdenticalCatches
         try {
-            final Object returnValue = createShortcuts.invoke(generated, context);
-            @SuppressWarnings("unchecked")
-            List<List<ShortcutInfo>> shortcuts = (List<List<ShortcutInfo>>) returnValue;
-            List<ShortcutInfo> enabledShortcuts = shortcuts.get(0);
-            List<String> disabledShortcutsIds = new ArrayList<>();
-            for (final ShortcutInfo shortcutInfo : shortcuts.get(1)) {
-                disabledShortcutsIds.add(shortcutInfo.getId());
-            }
-            shortcutManager.disableShortcuts(disabledShortcutsIds);
-            shortcutManager.setDynamicShortcuts(enabledShortcuts);
-            shortcutsSet = true;
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
+            generated = Class.forName("shortbread.ShortbreadGenerated");
+            Method createShortcuts = generated.getMethod("createShortcuts", Context.class);
+            returnValue = createShortcuts.invoke(generated, context);
+            return new ShortbreadBuilder(context, (List<ShortcutInfo>) returnValue);
+
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             e.printStackTrace();
         }
+        throw new IllegalStateException();
     }
 
-    @RequiresApi(14)
-    private static void setActivityLifecycleCallbacks(Context applicationContext) {
-        ((Application) applicationContext).registerActivityLifecycleCallbacks(new SimpleActivityLifecycleCallbacks() {
-
-            @Override
-            public void onActivityCreated(final Activity activity, final Bundle savedInstanceState) {
-                callMethodShortcut(activity);
-            }
-        });
-
-        activityLifecycleCallbacksSet = true;
-    }
-
-    private static void callMethodShortcut(Activity activity) {
-        //noinspection TryWithIdenticalCatches
-        try {
-            callMethodShortcut.invoke(generated, activity);
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
-        }
-    }
-
-    private Shortbread() {
-    }
 }

--- a/shortbread/src/main/java/shortbread/Shortbread.java
+++ b/shortbread/src/main/java/shortbread/Shortbread.java
@@ -15,14 +15,19 @@ public final class Shortbread {
 
     @TargetApi(25)
     @NonNull
-    public static ShortbreadBuilder generate(Context context) {
+    public static ShortbreadInitialBuilder generate(Context context) {
         final Object returnValue;
 
         try {
             generated = Class.forName("shortbread.ShortbreadGenerated");
             Method createShortcuts = generated.getMethod("createShortcuts", Context.class);
             returnValue = createShortcuts.invoke(generated, context);
-            return new ShortbreadBuilder(context, (List<ShortcutInfo>) returnValue);
+            boolean[] shortcutStatus = new boolean[((List<ShortcutInfo>) returnValue).size()];
+            // enable all shortcuts by default
+            for (int i = 0; i < shortcutStatus.length; i++) {
+                shortcutStatus[i] = true;
+            }
+            return new ShortbreadInitialBuilder(context, (List<ShortcutInfo>) returnValue, shortcutStatus);
 
         } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             e.printStackTrace();

--- a/shortbread/src/main/java/shortbread/ShortbreadBuilder.java
+++ b/shortbread/src/main/java/shortbread/ShortbreadBuilder.java
@@ -8,32 +8,15 @@ import java.util.List;
 
 public class ShortbreadBuilder {
 
-    private Context context;
-    private List<ShortcutInfo> allShortcuts = new ArrayList<>();
-    private boolean[] shortcutStatus;
+    Context context;
+    List<ShortcutInfo> allShortcuts = new ArrayList<>();
+    boolean[] shortcutStatus;
 
-    ShortbreadBuilder(Context context, List<ShortcutInfo> allShortcuts) {
+    ShortbreadBuilder(Context context, List<ShortcutInfo> allShortcuts, boolean[] shortcutStatus) {
 
         this.allShortcuts = allShortcuts;
-        this.shortcutStatus = new boolean[allShortcuts.size()];
-        // enable all shortcuts by default
-        for (int i = 0; i < shortcutStatus.length; i++) {
-            shortcutStatus[i] = true;
-        }
-
+        this.shortcutStatus = shortcutStatus;
         this.context = context;
-    }
-
-    /**
-     * Disable all available app shortcuts.
-     *
-     * @return shortbread builder.
-     */
-    public ShortbreadBuilder disableAll() {
-        for (int i = 0; i < shortcutStatus.length; i++) {
-            shortcutStatus[i] = false;
-        }
-        return this;
     }
 
     /**
@@ -48,6 +31,9 @@ public class ShortbreadBuilder {
         return this;
     }
 
+    /**
+     * Build the shortcuts
+     */
     public void build() {
         Creator.create(context, allShortcuts, shortcutStatus);
     }

--- a/shortbread/src/main/java/shortbread/ShortbreadBuilder.java
+++ b/shortbread/src/main/java/shortbread/ShortbreadBuilder.java
@@ -1,0 +1,63 @@
+package shortbread;
+
+import android.content.Context;
+import android.content.pm.ShortcutInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ShortbreadBuilder {
+
+    private Context context;
+    private List<ShortcutInfo> allShortcuts = new ArrayList<>();
+    private boolean[] shortcutStatus;
+
+    ShortbreadBuilder(Context context, List<ShortcutInfo> allShortcuts) {
+
+        this.allShortcuts = allShortcuts;
+        this.shortcutStatus = new boolean[allShortcuts.size()];
+        // enable all shortcuts by default
+        for (int i = 0; i < shortcutStatus.length; i++) {
+            shortcutStatus[i] = true;
+        }
+
+        this.context = context;
+    }
+
+    /**
+     * Disable all available app shortcuts.
+     *
+     * @return shortbread builder.
+     */
+    public ShortbreadBuilder disableAll() {
+        for (int i = 0; i < shortcutStatus.length; i++) {
+            shortcutStatus[i] = false;
+        }
+        return this;
+    }
+
+    /**
+     * Change the status for the app shortcut with the given {@code id}.
+     *
+     * @param id      the app shortcut id
+     * @param enabled true, if the shortcut should be enabled, otherwise false.
+     * @return shortbread builder
+     */
+    public ShortbreadBuilder setEnabled(int id, boolean enabled) {
+        shortcutStatus[getIndex(id)] = enabled;
+        return this;
+    }
+
+    public void build() {
+        Creator.create(context, allShortcuts, shortcutStatus);
+    }
+
+    private int getIndex(int id) {
+        for (int i = 0; i < allShortcuts.size(); i++) {
+            if (Integer.valueOf(allShortcuts.get(i).getId()) == id) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/shortbread/src/main/java/shortbread/ShortbreadInitialBuilder.java
+++ b/shortbread/src/main/java/shortbread/ShortbreadInitialBuilder.java
@@ -1,0 +1,36 @@
+package shortbread;
+
+import android.content.Context;
+import android.content.pm.ShortcutInfo;
+
+import java.util.List;
+
+public class ShortbreadInitialBuilder extends ShortbreadBuilder {
+
+    ShortbreadInitialBuilder(Context context, List<ShortcutInfo> allShortcuts, boolean[] shortcutStatus) {
+        super(context, allShortcuts, shortcutStatus);
+    }
+
+    /**
+     * Disable all available app shortcuts.
+     *
+     * @return shortbread builder.
+     */
+    public ShortbreadBuilder disableAll() {
+        for (int i = 0; i < shortcutStatus.length; i++) {
+            shortcutStatus[i] = false;
+        }
+        return new ShortbreadBuilder(context, allShortcuts, shortcutStatus);
+    }
+
+
+    @Override
+    public ShortbreadBuilder setEnabled(int id, boolean enabled) {
+        return super.setEnabled(id, enabled);
+    }
+
+    @Override
+    public void build() {
+        super.build();
+    }
+}


### PR DESCRIPTION
Add support for dynamic app shortcuts (#3). All annotated shortcuts are enabled by default. Two ways are provided to change their status:

1) **White listing**. Disable all shortcuts, then enable single shortcuts.
```
Shortbread.generate(this)
.disableAll()
.setEnabled(R.id.books, true)
.setEnabled(R.id.favorite_books, true)
.build();
```

2) **Black listing** . Disable single shortcuts.
```
Shortbread.generate(this)
.setEnabled(R.id.books, false)
.setEnabled(R.id.favorite_books, false)
.build();
```